### PR TITLE
Fix integration fixture download under gdown >= 6

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -120,9 +120,10 @@ def _download_google_drive(url: str, dest: Path) -> None:
         file_id = url
 
     try:
-        gdown.download(
-            id=file_id, output=str(dest), quiet=False, fuzzy=True, resume=True
-        )
+        # gdown >= 6 removed the fuzzy/resume keyword arguments; passing
+        # them raises TypeError before any download starts. `fuzzy` is only
+        # meaningful for URL (not id=) inputs anyway.
+        gdown.download(id=file_id, output=str(dest), quiet=False)
 
         if not dest.exists() or dest.stat().st_size == 0:
             raise RuntimeError("Download failed: file is empty or does not exist")


### PR DESCRIPTION
Closes #54.

This fixes the integration fixture downloader under `gdown >= 6`. The
previous code passed the `fuzzy` and `resume` arguments, which were removed
in gdown 6, while `pyproject.toml` does not pin gdown to an older compatible
version. The result is that a fresh environment can fail before the
integration tests even reach the fixture.

The change simply removes those unsupported arguments. This is safe because
`fuzzy` applies to URL-style inputs, while the downloader here passes a bare
Google Drive file ID rather than a URL. I verified the fix under
`gdown 6.1.0`: the suite changed from 26 errors before the fix to 22 passed,
34 skipped after the fix.

This PR is submitted as part of the JOSS review at
openjournals/joss-reviews#11196.
