### PR TITLE
Quick Start: WSIParser takes level, not mag_level

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -93,7 +93,7 @@ Use the `WSIParser` for advanced tiling operations:
        slide=slide_with_annotations,
        tile_dim=256,  # tile size
        border=slide_with_annotations.get_border(),
-       mag_level=0    # magnification level
+       level=0        # pyramid level
    )
 
    # Generate tiles
@@ -202,7 +202,7 @@ Here's a complete example that demonstrates a typical workflow:
        slide=slide_with_annotations,
        tile_dim=256,
        border=border,
-       mag_level=0
+       level=0
    )
 
    # 4. Generate tiles


### PR DESCRIPTION
Closes #52.

The two Quick Start examples currently pass `mag_level` to `WSIParser`, but
the current API expects `level`, causing:

```text
TypeError: WSIParser.__init__() got an unexpected keyword argument 'mag_level'
```

This is a documentation-only change affecting both examples, with no runtime
code changes. It addresses the Quick Start failure reported in #52 and is
submitted as part of the JOSS review at openjournals/joss-reviews#11196.
