### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: 'PySlyde: A Lightweight, Open-Source Toolkit for Pathology Preprocessing'
+type: software
+authors:
+- given-names: Gregory
+  family-names: Verghese
+- given-names: Anthony
+  family-names: Baptista
+- given-names: Chima
+  family-names: Eke
+- given-names: Holly
+  family-names: Rafique
+- given-names: Elizabeth
+  family-names: Ing-Simmons
+- given-names: Enrico
+  family-names: Parisini
+- given-names: Mengyuan
+  family-names: Li
+- given-names: Fathima
+  family-names: Mohamed
+- given-names: Ananya
+  family-names: Bhalla
+- given-names: Lucy
+  family-names: Ryan
+- given-names: Michael
+  family-names: Pitcher
+- given-names: Concetta
+  family-names: Piazzese
+- given-names: James
+  family-names: Graham
+- given-names: Dinis Pedro
+  family-names: Calado
+- given-names: Christopher R.S.
+  family-names: Banerji
+- given-names: Anita
+  family-names: Grigoriadis
+repository-code: https://github.com/PharosKCL/pyslyde
+license: MIT


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a "Cite this repository" button and citation tooling can read machine-readable metadata.

Author names and ORCIDs come from `paper.md`, and the licence from the LICENSE file. Validated with `cffconvert --validate` against schema 1.2.0.

Worth checking the given-name/family-name split per author, since some papers give a single `name` field.